### PR TITLE
Change texts for invalid pin response

### DIFF
--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -21,7 +21,10 @@
     <string name="auth_pin_title">Voer je eduID PIN in</string>
 
     <string name="notification_channel_description">Notificaties voor berichten van eduID</string>
-    
-   
+
+    <!-- De eduID server blokkeert geen accounts, maar gebruikt een incrementele backoff-tijd. Dit iz nog niet opgenomen in het protocoll.
+            Voor nu tonen we een aangepaste melding aan de gebruiker. -->
+    <string name="error_auth_title_blocked">Inloggen mislukt</string>
+    <string name="error_auth_blocked">Probeer het over een ogenblik opnieuw.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,10 @@
     <string name="auth_pin_title">Enter your eduID PIN</string>
 
     <string name="notification_channel_description">Notifications for messages from eduID</string>
+
+    <!-- The eduID server does not block accounts, but uses an incremental backoff-time. The tiqr-protocol has no way of communicating this yet.
+            For now, we just replace the message shown to the user -->
+    <string name="error_auth_title_blocked">Authentication failed</string>
+    <string name="error_auth_blocked">Try again in a moment.</string>
+
 </resources>


### PR DESCRIPTION
### Pull Request Checklist
- [x] I have added proper commit messages
- [ ] I have updated tests and documentation
- [ ] I ran the tests
- [ ] I provided the ticket number as PR title
- [x] I have assigned the required reviewers

### Short Description of Change
<!-- Please provide information regarding the change -->
```
The eduID server uses a incremental backoff time if the user enters a incorrect pin, but the response is interpreted as a blocked account in the tiqr app. 
```

