### PR TITLE
Include core SHA as part of the version name.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,11 +28,12 @@ android {
 
     val gitTagCount = "git tag --list".runCommand().split('\n').size
     val gitTag = "git describe --tags --dirty".runCommand()
+    val gitCoreSha = "git submodule status".runCommand().substring(0, 8)
 
     defaultConfig {
         applicationId = "nl.eduid"
-        versionCode = gitTagCount.toInt()
-        versionName = gitTag.toString().trim().drop(1)
+        versionCode = gitTagCount
+        versionName = gitTag.trim().drop(1) + " core($gitCoreSha)"
 
         minSdk = libs.versions.android.sdk.min.get().toInt()
         targetSdk = libs.versions.android.sdk.target.get().toInt()
@@ -41,7 +42,7 @@ android {
 
         manifestPlaceholders["tiqr_config_base_url"] = "https://demo.tiqr.org"
         manifestPlaceholders["tiqr_config_protocol_version"] = "2"
-        manifestPlaceholders["tiqr_config_protocol_compatibility_mode"] =  "true"
+        manifestPlaceholders["tiqr_config_protocol_compatibility_mode"] = "true"
         manifestPlaceholders["tiqr_config_enforce_challenge_hosts"] = "eduid.nl,surfconext.nl"
         manifestPlaceholders["tiqr_config_enroll_path_param"] = "tiqrenroll"
         manifestPlaceholders["tiqr_config_auth_path_param"] = "tiqrauth"


### PR DESCRIPTION
### Pull Request Checklist
- [x] I have added proper commit messages
- [] I have updated tests and documentation
- [x] I ran the tests
- [x] I provided the ticket number as PR title
- [ ] I have assigned the required reviewers

### Short Description of Change
<!-- Please provide information regarding the change -->
```
Added the core SHA value to the app's version name.
```

### Motivation and Context
<!-- Please provide why this change was required -->
```
Currently the app-core submodule dependency is not using any tagging mechanism and since gradle no longer supports version codes for android libraries, the next best thing is to use the commit SHA of the git submodule. 
```

### Testing Steps
<!-- Please provide steps to test (manual/automation) to verify the change -->
```
Open the About screen
```

### Additional Information
<!-- Please provide any additional information or screenshot -->

<img width="454" alt="Screenshot 2022-11-17 at 12 06 18" src="https://user-images.githubusercontent.com/2356050/202431395-896adc96-c4c5-45c0-bb59-ca0312ca6ae4.png">