### PR TITLE
Add internal signed release to GHA builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
-name: Debug Build
+name: Build
 on:
   pull_request:
-  push:
-    branches:
-      - main
-      - develop
 # Where will they run
 jobs:
   build:
@@ -20,16 +16,6 @@ jobs:
         distribution: 'temurin'
         cache: 'gradle'
     - name: Build nl.eduid APK
-      run: bash ./gradlew assembleRelease --stacktrace
-    - name: Build nl.eduid.testing APK
-      run: bash ./gradlew assembleDebug --stacktrace
-    - name: Upload APK
-      uses: actions/upload-artifact@v1
-      with:
-        name: app-release-unsigned
-        path: app/build/outputs/apk/release/app-release-unsigned.apk
-    - name: Upload testing APK
-      uses: actions/upload-artifact@v1
-      with:
-        name: app-debug
-        path: app/build/outputs/apk/debug/app-debug.apk
+      run: bash ./gradlew assembleProdRelease --stacktrace
+    - name: Build nl.eduid Bundle
+      run: bash ./gradlew bundleProdRelease --stacktrace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
-name: Release Build
+name: Create signed release for Playstore
 on:
-  workflow_dispatch:
   push:
     tags:
       - 'v*'
@@ -19,29 +18,28 @@ jobs:
         cache: 'gradle'
 
     - name: Build APK
-      run: ./gradlew assembleRelease
+      run: ./gradlew assembleProdRelease
     - name: Sign APK
       id: sign_apk
       uses: r0adkll/sign-android-release@v1
       with:
-        releaseDirectory: app/build/outputs/apk/release/
+        releaseDirectory: app/build/outputs/apk/prod/release/
         signingKeyBase64: ${{ secrets.SIGNINGKEYBASE64 }}
         alias: ${{ secrets.ALIAS }}
         keyStorePassword: ${{ secrets.KEYSTOREPASSWORD }}
         keyPassword: ${{ secrets.KEYPASSWORD }}
 
     - name: Build App bundle
-      run: ./gradlew bundleRelease
+      run: ./gradlew bundleProdRelease
     - name: Sign App Bundle
       id: sign_aab
       uses: r0adkll/sign-android-release@v1
       with:
-        releaseDirectory: app/build/outputs/bundle/release/
+        releaseDirectory: app/build/outputs/bundle/prodRelease/
         signingKeyBase64: ${{ secrets.SIGNINGKEYBASE64 }}
         alias: ${{ secrets.ALIAS }}
         keyStorePassword: ${{ secrets.KEYSTOREPASSWORD }}
         keyPassword: ${{ secrets.KEYPASSWORD }}
-
 
     - name: Build Changelog
       id: changelog

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,34 @@
+name: Create signed testing release for internal use
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: recursive
+    - uses: actions/setup-java@v2
+      with:
+        java-version: 11
+        distribution: 'temurin'
+        cache: 'gradle'
+
+    - name: Build APK
+      run: ./gradlew assembleInternalRelease
+    - name: Sign APK
+      id: sign_apk
+      uses: r0adkll/sign-android-release@v1
+      with:
+        releaseDirectory: app/build/outputs/apk/internal/release/
+        signingKeyBase64: ${{ secrets.SIGNINGKEYBASE64 }}
+        alias: ${{ secrets.ALIAS }}
+        keyStorePassword: ${{ secrets.KEYSTOREPASSWORD }}
+        keyPassword: ${{ secrets.KEYPASSWORD }}
+
+    - name: Upload APK
+      uses: actions/upload-artifact@v1
+      with:
+        name: eduID-${{ github.ref_name }}-testing.apk
+        path: ${{steps.sign_apk.outputs.signedReleaseFile}}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,6 +27,7 @@ android {
     buildToolsVersion = libs.versions.android.buildTools.get()
 
     val gitTagCount = "git tag --list".runCommand().split('\n').size
+    val gitCommitCount = "git rev-list --all --count".runCommand().toInt()
     val gitTag = "git describe --tags --dirty".runCommand()
     val gitCoreSha = "git submodule status".runCommand().substring(0, 8)
 
@@ -58,13 +59,27 @@ android {
         }
     }
 
+    flavorDimensions += "version"
+    productFlavors {
+        create("internal") {
+          dimension = "version"
+          versionCode = gitCommitCount
+          applicationIdSuffix = ".testing"
+          versionName = gitTag.trim().drop(1) + " core($gitCoreSha) internal"
+        }
+        create("prod") {
+          dimension = "version"
+          versionCode = gitTagCount
+          versionName = gitTag.trim().drop(1) + " core($gitCoreSha)"
+        }
+    }
+
     buildTypes {
         getByName("release") {
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
         }
-
         getByName("debug") {
             applicationIdSuffix = ".testing"
         }


### PR DESCRIPTION
### Pull Request Checklist
- [x] I have added proper commit messages
- [ ] I have updated tests and documentation
- [ ] I ran the tests
- [ ] I provided the ticket number as PR title
- [x] I have assigned the required reviewers

### Short Description of Change
<!-- Please provide information regarding the change -->
```
This will change the Github Actions build workflows. 3 workflows are available:
- build.yml - Builds an unsigned release to check for errors, will run on PR's 
- testing.yml - Builds an signed testing release APK for internal use (sideloading), will run on manual triggers
- release.yml - Creates an signed APK and app-bundle. Will run when an tag is set 
```

