### PR TITLE
Edured-97: Fix cannot get account details.

### DIFF
--- a/app/src/main/kotlin/nl/eduid/di/model/EduIdModels.kt
+++ b/app/src/main/kotlin/nl/eduid/di/model/EduIdModels.kt
@@ -85,7 +85,7 @@ data class EduIdPerServiceProvider(
     val value: String,
     val serviceName: String,
     val serviceNameNl: String,
-    val serviceLogoUrl: String,
+    val serviceLogoUrl: String?,
     val createdAt: Long,
 ) : Parcelable
 

--- a/app/src/main/kotlin/nl/eduid/screens/dataactivity/DataAndActivityData.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/dataactivity/DataAndActivityData.kt
@@ -6,5 +6,5 @@ data class ServiceProvider(
     val firstLoginStamp: Long,
     val uniqueId: String,
     val serviceProviderEntityId: String,
-    val providerLogoUrl: String,
+    val providerLogoUrl: String?,
 )

--- a/app/src/main/kotlin/nl/eduid/screens/dataactivity/DataAndActivityScreen.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/dataactivity/DataAndActivityScreen.kt
@@ -105,7 +105,7 @@ fun DataAndActivityScreenContent(
     } else {
         data.forEach { provider ->
             LoginInfoCard(
-                startIconLargeUrl = provider.providerLogoUrl,
+                startIconLargeUrl = provider.providerLogoUrl.orEmpty(),
                 title = provider.providerName,
                 subtitle = stringResource(
                     R.string.data_info_on_date, provider.firstLoginStamp.getDateTimeString()


### PR DESCRIPTION
Make serviceLogoUrl a nullable field to allow for missing value.

### Short Description of Change
For this particular account the `serviceLogoUrl` was null. This caused parsing of the response to fail.


https://github.com/Tiqr/eduid-app-android/assets/2356050/432b4b7d-5cfb-4261-a15b-34f9d0753240

