### PR TITLE
Edured-105: Reopen settings after password configuration

### DIFF
--- a/app/src/main/kotlin/nl/eduid/graphs/ConfigurePassword.kt
+++ b/app/src/main/kotlin/nl/eduid/graphs/ConfigurePassword.kt
@@ -19,7 +19,10 @@ import nl.eduid.screens.resetpassword.ResetPasswordViewModel
 import nl.eduid.screens.resetpasswordconfirm.ResetPasswordConfirmScreen
 import nl.eduid.screens.resetpasswordconfirm.ResetPasswordConfirmViewModel
 
-fun NavGraphBuilder.configurePasswordFlow(navController: NavHostController) {
+fun NavGraphBuilder.configurePasswordFlow(
+    navController: NavHostController,
+    onConfigDone: () -> Unit,
+) {
     navigation(
         startDestination = Request.route,
         route = Graph.CONFIGURE_PASSWORD,
@@ -64,7 +67,8 @@ fun NavGraphBuilder.configurePasswordFlow(navController: NavHostController) {
             ResetPasswordConfirmScreen(
                 viewModel = viewModel,
                 isAddPassword = isAddPassword,
-                goBack = { navController.popBackStack() },
+                goBack = navController::popBackStack,
+                onConfigDone = onConfigDone
             )
         }//endregion
 

--- a/app/src/main/kotlin/nl/eduid/graphs/MainGraph.kt
+++ b/app/src/main/kotlin/nl/eduid/graphs/MainGraph.kt
@@ -451,7 +451,7 @@ fun MainGraph(
         )
     }
     //region Configure Password: add, change or remove
-    configurePasswordFlow(navController)
+    configurePasswordFlow(navController) { navController.navigate(Security.Settings.route) }
     //endregion
 }
 

--- a/app/src/main/kotlin/nl/eduid/screens/resetpasswordconfirm/ResetPasswordConfirmScreen.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/resetpasswordconfirm/ResetPasswordConfirmScreen.kt
@@ -69,6 +69,7 @@ fun ResetPasswordConfirmScreen(
     viewModel: ResetPasswordConfirmViewModel,
     isAddPassword: Boolean,
     goBack: () -> Unit,
+    onConfigDone: () -> Unit,
 ) = EduIdTopAppBar(
     onBackClicked = goBack,
 ) {
@@ -86,12 +87,12 @@ fun ResetPasswordConfirmScreen(
     }
 
     if (waitForVmEvent) {
-        val currentGoBack by rememberUpdatedState(newValue = goBack)
+        val currentOnConfigDone by rememberUpdatedState(newValue = onConfigDone)
         LaunchedEffect(viewModel, lifecycle) {
             snapshotFlow { viewModel.uiState }.distinctUntilChanged()
                 .filter { it.isCompleted != null }.flowWithLifecycle(lifecycle).collect {
                     waitForVmEvent = false
-                    currentGoBack()
+                    currentOnConfigDone()
                     viewModel.clearCompleted()
                 }
         }


### PR DESCRIPTION
Make sure that after the password configuration is done, the Security settings screen is reopened instead of just popping the navigation stack.


https://github.com/Tiqr/eduid-app-android/assets/2356050/62b2317c-ea59-4d9a-a4b8-dc3a720d6e4b

