### PR TITLE
TIQR-373: Don't start recovery in the app when a second key is added.

### DIFF
--- a/app/src/main/kotlin/nl/eduid/BaseViewModel.kt
+++ b/app/src/main/kotlin/nl/eduid/BaseViewModel.kt
@@ -7,7 +7,9 @@ import org.tiqr.data.model.AuthenticationChallenge
 import org.tiqr.data.model.Challenge
 import org.tiqr.data.model.EnrollmentChallenge
 
-open class BaseViewModel(private val moshi: Moshi) : ViewModel() {
+open class BaseViewModel(
+    private val moshi: Moshi,
+) : ViewModel() {
 
     fun encodeChallenge(scanResult: Challenge): String {
         val asJson: String = when (scanResult) {
@@ -15,6 +17,7 @@ open class BaseViewModel(private val moshi: Moshi) : ViewModel() {
                 val adapter = moshi.adapter(EnrollmentChallenge::class.java)
                 adapter.toJson(scanResult)
             }
+
             is AuthenticationChallenge -> {
                 val adapter = moshi.adapter(AuthenticationChallenge::class.java)
                 adapter.toJson(scanResult)

--- a/app/src/main/kotlin/nl/eduid/CheckRecovery.kt
+++ b/app/src/main/kotlin/nl/eduid/CheckRecovery.kt
@@ -1,0 +1,24 @@
+package nl.eduid
+
+import nl.eduid.screens.personalinfo.PersonalInfoRepository
+
+class CheckRecovery(
+    private val personal: PersonalInfoRepository,
+) {
+
+    /**
+     * Returns true if the authentication available in the app matches the stored key id. This is
+     * required in order to keep backwards compatibility. If the account was created outside the app,
+     * then the recovery flow is automatically fired by the web page once the app has enrolled.
+     * If the app also fires off a recovery flow, this results in a race condition for which of the
+     * 2 recoveries (web or app) should be completed.
+     * */
+    @SuppressWarnings("unused")
+    suspend fun shouldAppDoRecoveryForIdentity(keyIdentifier: String): Boolean {
+        val userDetails = personal.getUserDetails()
+        val isAuthenticated = userDetails != null
+        val haveKeyForAuthenticatedAccount = keyIdentifier == userDetails?.id
+        return isAuthenticated && haveKeyForAuthenticatedAccount
+    }
+
+}

--- a/app/src/main/kotlin/nl/eduid/graphs/MainGraph.kt
+++ b/app/src/main/kotlin/nl/eduid/graphs/MainGraph.kt
@@ -126,30 +126,29 @@ fun MainGraph(
     ) { entry ->
         val viewModel = hiltViewModel<RegistrationPinSetupViewModel>(entry)
         RegistrationPinSetupScreen(viewModel = viewModel,
-            closePinSetupFlow = { navController.popBackStack() },
-            goToNextStep = { nextStep ->
-                when (nextStep) {
-                    NextStep.RecoveryInBrowser -> {
-                        navController.navigate(Graph.CONTINUE_RECOVERY_IN_BROWSER)
-                    }
+            closePinSetupFlow = { navController.popBackStack() }
+        ) { nextStep ->
+            when (nextStep) {
+                NextStep.RecoveryInBrowser -> {
+                    navController.navigate(Graph.CONTINUE_RECOVERY_IN_BROWSER)
+                }
 
-                    is NextStep.PromptBiometric -> {
-                        navController.navigate(
-                            WithChallenge.EnableBiometric.buildRouteForEnrolment(
-                                encodedChallenge = viewModel.encodeChallenge(nextStep.challenge),
-                                pin = nextStep.pin
-                            )
-                        ) {
-                            popUpTo(Graph.HOME_PAGE)
-                        }
-                    }
-
-                    NextStep.Recovery -> navController.navigate(PhoneNumberRecovery.RequestCode.route) {
+                is NextStep.PromptBiometric -> {
+                    navController.navigate(
+                        WithChallenge.EnableBiometric.buildRouteForEnrolment(
+                            encodedChallenge = viewModel.encodeChallenge(nextStep.challenge),
+                            pin = nextStep.pin
+                        )
+                    ) {
                         popUpTo(Graph.HOME_PAGE)
                     }
                 }
-            },
-            promptAuth = { navController.navigate(Graph.OAUTH) })
+
+                NextStep.Recovery -> navController.navigate(PhoneNumberRecovery.RequestCode.route) {
+                    popUpTo(Graph.HOME_PAGE)
+                }
+            }
+        }
     }//endregion
 
     //region Authentication
@@ -182,8 +181,8 @@ fun MainGraph(
         route = WithChallenge.EnableBiometric.routeWithArgs, arguments = WithChallenge.arguments
     ) { entry ->
         val viewModel = hiltViewModel<EnableBiometricViewModel>(entry)
-        EnableBiometricScreen(viewModel = viewModel, goToNext = { askRecovery ->
-            if (askRecovery) {
+        EnableBiometricScreen(viewModel = viewModel, goToNext = { shouldAskForRecovery ->
+            if (shouldAskForRecovery) {
                 navController.navigate(PhoneNumberRecovery.RequestCode.route) {
                     popUpTo(Graph.HOME_PAGE)
                 }
@@ -352,6 +351,7 @@ fun MainGraph(
                     Intent::class.java
                 )
             } else {
+                @Suppress("DEPRECATION")
                 entry.arguments?.getParcelable(
                     NavController.KEY_DEEP_LINK_INTENT
                 )

--- a/app/src/main/kotlin/nl/eduid/screens/biometric/EnableBiometricScreen.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/biometric/EnableBiometricScreen.kt
@@ -58,7 +58,7 @@ fun EnableBiometricScreen(
     if (waitingForVmEvent) {
         val currentGoToNextStep by rememberUpdatedState(goToNext)
         LaunchedEffect(lifecycle) {
-            snapshotFlow { viewModel.isCompleted }.distinctUntilChanged().filterNotNull()
+            snapshotFlow { viewModel.shouldAskForRecovery }.distinctUntilChanged().filterNotNull()
                 .flowWithLifecycle(lifecycle).collect {
                     waitingForVmEvent = false
                     currentGoToNextStep(it)

--- a/app/src/main/kotlin/nl/eduid/screens/pinsetup/RegistrationPinSetupScreen.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/pinsetup/RegistrationPinSetupScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -29,7 +28,6 @@ fun RegistrationPinSetupScreen(
     viewModel: RegistrationPinSetupViewModel,
     closePinSetupFlow: () -> Unit,
     goToNextStep: (NextStep) -> Unit,
-    promptAuth: () -> Unit,
 ) {
     BackHandler { viewModel.handleBackNavigation(closePinSetupFlow) }
     //Because the same screen is being used for creating the PIN as well as confirming the PIN
@@ -39,14 +37,10 @@ fun RegistrationPinSetupScreen(
     EduIdTopAppBar(
         onBackClicked = dispatcher::onBackPressed,
     ) {
-        val isAuthorized by viewModel.isAuthorized.observeAsState(initial = null)
-
         RegistrationPinSetupContent(
             uiState = viewModel.uiState,
-            isAuthorized = isAuthorized,
             padding = it,
             goToNextStep = goToNextStep,
-            promptAuth = promptAuth,
             viewModel = viewModel,
         )
     }
@@ -55,10 +49,8 @@ fun RegistrationPinSetupScreen(
 @Composable
 private fun RegistrationPinSetupContent(
     uiState: UiState,
-    isAuthorized: Boolean? = null,
     padding: PaddingValues = PaddingValues(),
     goToNextStep: (NextStep) -> Unit = {},
-    promptAuth: () -> Unit = {},
     viewModel: RegistrationPinSetupViewModel,
 ) {
     var enrollmentInProgress by rememberSaveable { mutableStateOf(false) }

--- a/app/src/main/kotlin/nl/eduid/screens/pinsetup/UiState.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/pinsetup/UiState.kt
@@ -8,7 +8,6 @@ data class UiState(
     val pinValue: String = "",
     val pinConfirmValue: String = "",
     val isPinInvalid: Boolean = false,
-    val promptAuth: Boolean? = null,
     val nextStep: NextStep? = null,
     val errorData: ErrorData? = null,
     val isProcessing: Boolean = false,


### PR DESCRIPTION
Shows go the "Go to browser to complete recovery" screen when a second key is added for an account that was created outside the app.

https://github.com/Tiqr/eduid-app-android/assets/2356050/3a250f35-28d2-46cf-808d-e5892f7d5f35

