### PR TITLE
TIQR-403: Fix welcome screen alignment

### DIFF
--- a/app/src/main/kotlin/nl/eduid/screens/firsttimedialog/FirstTimeDialogScreen.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/firsttimedialog/FirstTimeDialogScreen.kt
@@ -4,9 +4,11 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -45,52 +47,55 @@ import nl.eduid.ui.theme.EduidAppAndroidTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun FirstTimeDialogScreen(
-    viewModel: LinkAccountViewModel,
-    goToAccountLinked: () -> Unit,
-    skipThis: () -> Unit,
-) = Scaffold(modifier = Modifier.systemBarsPadding(), topBar = {
-    CenterAlignedTopAppBar(
-        title = {},
-        actions = {
-            Image(painter = painterResource(R.drawable.close_x_icon),
-                contentDescription = "",
-                modifier = Modifier
-                    .size(width = 48.dp, height = 48.dp)
-                    .clickable {
-                        skipThis()
-                    })
-        },
-        modifier = Modifier.padding(horizontal = 30.dp),
-    )
-}) { paddingValues ->
-    var isGettingLinkUrl by rememberSaveable { mutableStateOf(false) }
-    var isLinkingStarted by rememberSaveable { mutableStateOf(false) }
-    val launcher =
-        rememberLauncherForActivityResult(contract = LinkAccountContract(), onResult = { _ ->
-            if (isLinkingStarted) {
-                goToAccountLinked()
-                isLinkingStarted = false
-            }
-        })
+fun FirstTimeDialogScreen(viewModel: LinkAccountViewModel, goToAccountLinked: () -> Unit, skipThis: () -> Unit) =
+    Scaffold(modifier = Modifier.systemBarsPadding(), topBar = {
+        CenterAlignedTopAppBar(
+            title = {},
+            actions = {
+                Image(
+                    painter = painterResource(R.drawable.close_x_icon),
+                    contentDescription = "",
+                    modifier = Modifier
+                        .size(width = 48.dp, height = 48.dp)
+                        .clickable {
+                            skipThis()
+                        },
+                )
+            },
+            modifier = Modifier.padding(horizontal = 30.dp),
+        )
+    }) { paddingValues ->
+        var isGettingLinkUrl by rememberSaveable { mutableStateOf(false) }
+        var isLinkingStarted by rememberSaveable { mutableStateOf(false) }
+        val launcher =
+            rememberLauncherForActivityResult(contract = LinkAccountContract(), onResult = { _ ->
+                if (isLinkingStarted) {
+                    goToAccountLinked()
+                    isLinkingStarted = false
+                }
+            })
 
-    if (isGettingLinkUrl && viewModel.uiState.haveValidLinkIntent()) {
-        LaunchedEffect(key1 = viewModel) {
-            viewModel.uiState.linkUrl?.let { intent ->
-                isGettingLinkUrl = false
-                launcher.launch(intent)
-                isLinkingStarted = true
+        if (isGettingLinkUrl && viewModel.uiState.haveValidLinkIntent()) {
+            LaunchedEffect(key1 = viewModel) {
+                viewModel.uiState.linkUrl?.let { intent ->
+                    isGettingLinkUrl = false
+                    launcher.launch(intent)
+                    isLinkingStarted = true
+                }
             }
         }
-    }
 
-    FirstTimeDialogContent(
-        uiState = viewModel.uiState, paddingValues = paddingValues, onClick = {
-            isGettingLinkUrl = true
-            viewModel.requestLinkUrl()
-        }, skipThis = skipThis, dismissError = viewModel::dismissError
-    )
-}
+        FirstTimeDialogContent(
+            uiState = viewModel.uiState,
+            paddingValues = paddingValues,
+            onClick = {
+                isGettingLinkUrl = true
+                viewModel.requestLinkUrl()
+            },
+            skipThis = skipThis,
+            dismissError = viewModel::dismissError,
+        )
+    }
 
 @Composable
 private fun FirstTimeDialogContent(
@@ -106,7 +111,7 @@ private fun FirstTimeDialogContent(
             title = uiState.errorData.title(context),
             explanation = uiState.errorData.message(context),
             buttonLabel = stringResource(R.string.Button_OK_COPY),
-            onDismiss = dismissError
+            onDismiss = dismissError,
         )
     }
 
@@ -114,12 +119,12 @@ private fun FirstTimeDialogContent(
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(paddingValues)
+            .padding(paddingValues),
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .weight(1f)
+                .weight(1f),
         ) {
             Text(
                 text = stringResource(R.string.CreateEduID_FirstTimeDialog_MainTextTitle_FirstPart_COPY),
@@ -131,7 +136,8 @@ private fun FirstTimeDialogContent(
             Text(
                 text = stringResource(R.string.CreateEduID_FirstTimeDialog_MainTextTitle_SecondPart_COPY),
                 style = MaterialTheme.typography.titleMedium.copy(
-                    color = ColorMain_Green_400, textAlign = TextAlign.Center
+                    color = ColorMain_Green_400,
+                    textAlign = TextAlign.Center,
                 ),
                 modifier = Modifier
                     .fillMaxWidth()
@@ -141,23 +147,28 @@ private fun FirstTimeDialogContent(
             Spacer(Modifier.height(40.dp))
 
             Box(Modifier.background(color = AlertWarningBackground)) {
-                Text(
-                    style = MaterialTheme.typography.bodyLarge,
-                    text = annotatedStringWithBoldParts(
-                        stringResource(id = R.string.CreateEduID_FirstTimeDialog_MainText_COPY),
-                        stringResource(id = R.string.CreateEduID_FirstTimeDialog_MainTextFirstBoldPart_COPY),
-                        stringResource(id = R.string.CreateEduID_FirstTimeDialog_MainTextSecondBoldPart_COPY),
-                    ),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 24.dp)
-                )
+                Column(modifier = Modifier.padding(vertical = 24.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        style = MaterialTheme.typography.bodyLarge,
+                        text = annotatedStringWithBoldParts(
+                            stringResource(id = R.string.CreateEduID_FirstTimeDialog_MainText_COPY),
+                            stringResource(id = R.string.CreateEduID_FirstTimeDialog_MainTextFirstBoldPart_COPY),
+                            stringResource(id = R.string.CreateEduID_FirstTimeDialog_MainTextSecondBoldPart_COPY),
+                        ),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp),
+                    )
+                    InfoAddedToEduId(R.string.CreateEduID_FirstTimeDialog_MainTextPoint1_COPY)
+                    InfoAddedToEduId(R.string.CreateEduID_FirstTimeDialog_MainTextPoint2_COPY)
+                    InfoAddedToEduId(R.string.CreateEduID_FirstTimeDialog_MainTextPoint3_COPY)
+                }
             }
         }
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(start = 24.dp, end = 24.dp, bottom = 24.dp)
+                .padding(start = 24.dp, end = 24.dp, bottom = 24.dp),
         ) {
             Text(
                 style = MaterialTheme.typography.bodyLarge,
@@ -165,13 +176,13 @@ private fun FirstTimeDialogContent(
                     stringResource(id = R.string.CreateEduID_FirstTimeDialog_AddInformationText_COPY),
                     stringResource(id = R.string.CreateEduID_FirstTimeDialog_AddInformationBoldPart_COPY),
                 ),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             )
             Spacer(Modifier.height(8.dp))
             PrimaryButton(
                 text = stringResource(R.string.CreateEduID_FirstTimeDialog_ConnectButtonTitle_COPY),
                 onClick = onClick,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             )
             Spacer(Modifier.height(24.dp))
             SecondaryButton(
@@ -183,8 +194,24 @@ private fun FirstTimeDialogContent(
     }
 }
 
+@Composable
+private fun InfoAddedToEduId(labelResId: Int) = Row(
+    modifier = Modifier
+        .fillMaxWidth()
+        .padding(start = 48.dp, end = 24.dp),
+    horizontalArrangement = Arrangement.Start,
+) {
+    Text(
+        text = "• ",
+        style = MaterialTheme.typography.bodyLarge,
+    )
+    Text(
+        text = stringResource(labelResId),
+        style = MaterialTheme.typography.bodyLarge,
+    )
+}
 
-@Preview()
+@Preview
 @Composable
 private fun PreviewFirstTimeDialogScreen() {
     EduidAppAndroidTheme {

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -710,7 +710,10 @@
   <string name="CreateEduID_FirstTimeDialog_ConnectButtonTitle_COPY">"Sluit je school/instelling aan"</string>
   <string name="CreateEduID_FirstTimeDialog_MainTextTitle_FirstPart_COPY">"Studeer je in Nederland?"</string>
   <string name="CreateEduID_FirstTimeDialog_MainTextTitle_SecondPart_COPY">"Sluit dan je instelling aan!"</string>
-  <string name="CreateEduID_FirstTimeDialog_MainText_COPY">"Wanneer je in Nederland studeert en je wilt met eduID inloggen bij een onderwijsdienst, moeten we er zeker van zijn dat jij het bent en niet iemand die zich voordoet als jij.\n\nDaarom moet je de volgende gegevens toevoegen aan jouw eduID:\n    • Validatie van je volledige naam door een derde partij\n    • Bewijs dat je student bent\n    • Je huidige instelling"</string>
+  <string name="CreateEduID_FirstTimeDialog_MainText_COPY">"Wanneer je in Nederland studeert en je wilt met eduID inloggen bij een onderwijsdienst, moeten we er zeker van zijn dat jij het bent en niet iemand die zich voordoet als jij.\n\nDaarom moet je de volgende gegevens toevoegen aan jouw eduID:"</string>
+  <string name="CreateEduID_FirstTimeDialog_MainTextPoint1_COPY">"Validatie van je volledige naam door een derde partij"</string>
+  <string name="CreateEduID_FirstTimeDialog_MainTextPoint2_COPY">"Bewijs dat je student bent"</string>
+  <string name="CreateEduID_FirstTimeDialog_MainTextPoint3_COPY">"Je huidige instelling"</string>
   <string name="CreateEduID_FirstTimeDialog_MainTextFirstBoldPart_COPY">"Wanneer je in Nederland studeert"</string>
   <string name="CreateEduID_FirstTimeDialog_MainTextSecondBoldPart_COPY">"Daarom moet je de volgende gegevens toevoegen aan jouw eduID:"</string>
   <string name="CreateEduID_FirstTimeDialog_AddInformationText_COPY">"Voeg deze informatie toe door je school/instelling aan te sluiten via SURFconext"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -710,7 +710,10 @@
   <string name="CreateEduID_FirstTimeDialog_ConnectButtonTitle_COPY">"Connect your school/institution"</string>
   <string name="CreateEduID_FirstTimeDialog_MainTextTitle_FirstPart_COPY">"Are you studying in NL?"</string>
   <string name="CreateEduID_FirstTimeDialog_MainTextTitle_SecondPart_COPY">"Connect your institution!"</string>
-  <string name="CreateEduID_FirstTimeDialog_MainText_COPY">"When you study in the Netherlands and you want to use eduID to logon to an educational services, we need to be sure it is you and not someone impersonating you.\n\nYou must therefore add the following information to your eduID:\n    • Validation of your full name by a third party\n    • Proof of being a student\n    • Your current institution"</string>
+  <string name="CreateEduID_FirstTimeDialog_MainText_COPY">"When you study in the Netherlands and you want to use eduID to logon to an educational services, we need to be sure it is you and not someone impersonating you.\n\nYou must therefore add the following information to your eduID:"</string>
+  <string name="CreateEduID_FirstTimeDialog_MainTextPoint1_COPY">"Validation of your full name by a third party"</string>
+  <string name="CreateEduID_FirstTimeDialog_MainTextPoint2_COPY">"Proof of being a student"</string>
+  <string name="CreateEduID_FirstTimeDialog_MainTextPoint3_COPY">"Your current institution"</string>
   <string name="CreateEduID_FirstTimeDialog_MainTextFirstBoldPart_COPY">"When you study in the Netherlands"</string>
   <string name="CreateEduID_FirstTimeDialog_MainTextSecondBoldPart_COPY">"You must therefore add the following information to your eduID:"</string>
   <string name="CreateEduID_FirstTimeDialog_AddInformationText_COPY">"Add this information by connecting your school/institution via SURFconext"</string>

--- a/localizations.yaml
+++ b/localizations.yaml
@@ -3501,18 +3501,25 @@ SHARED:
             
             
             You must therefore add the following information to your eduID:
-                • Validation of your full name by a third party
-                • Proof of being a student
-                • Your current institution
           nl: >-
             Wanneer je in Nederland studeert en je wilt met eduID inloggen bij een onderwijsdienst,
             moeten we er zeker van zijn dat jij het bent en niet iemand die zich voordoet als jij.
             
             
             Daarom moet je de volgende gegevens toevoegen aan jouw eduID:
-                • Validatie van je volledige naam door een derde partij
-                • Bewijs dat je student bent
-                • Je huidige instelling
+      MainTextPoint1:
+        COPY:
+          en: Validation of your full name by a third party
+          nl: Validatie van je volledige naam door een derde partij
+      MainTextPoint2:
+        COPY:
+          en: Proof of being a student
+          nl: Bewijs dat je student bent
+      MainTextPoint3:
+        COPY:
+          en: Your current institution
+          nl: Je huidige instelling
+
       MainTextFirstBoldPart:
         COPY:
           en: When you study in the Netherlands


### PR DESCRIPTION
Request was to align the text from the bullet points: if the text wraps to a second line, the second line should be aligned with the start of the text, not with the start of the row.

⚠️ **NB:** This change for shared resources will break iOS, strings changes must not be merged without code changes.

<img width="339" alt="Screenshot 2024-07-04 at 16 08 10" src="https://github.com/Tiqr/eduid-app-android/assets/2356050/fe86e026-bd1b-4078-ba1b-06cca088f0f6">

CC: @dzolnai 