### PR TITLE
TIQR-453: Clear last notification challenge when opening one

### DIFF
--- a/app/src/main/kotlin/nl/eduid/screens/deeplinks/DeepLinkScreen.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/deeplinks/DeepLinkScreen.kt
@@ -51,6 +51,7 @@ fun DeepLinkScreen(
         LaunchedEffect(key1 = dataString) {
             isParsingLinkPayload = true
             val parseResult = viewModel.parseChallenge(dataString)
+            viewModel.clearLastNotificationChallenge()
             if (parseResult is ChallengeParseResult.Failure) {
                 errorData = ErrorData(parseResult.failure.title, parseResult.failure.message)
             } else if (parseResult is ChallengeParseResult.Success) {

--- a/app/src/main/kotlin/nl/eduid/screens/deeplinks/DeepLinkViewModel.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/deeplinks/DeepLinkViewModel.kt
@@ -11,6 +11,7 @@ import org.tiqr.data.model.ChallengeParseResult
 import org.tiqr.data.model.ParseFailure
 import org.tiqr.data.repository.AuthenticationRepository
 import org.tiqr.data.repository.EnrollmentRepository
+import org.tiqr.data.repository.NotificationCacheRepository
 import javax.inject.Inject
 
 @HiltViewModel
@@ -18,6 +19,7 @@ class DeepLinkViewModel @Inject constructor(
     private val resources: Resources,
     private val enroll: EnrollmentRepository,
     private val auth: AuthenticationRepository,
+    private val notificationCacheRepository: NotificationCacheRepository,
     moshi: Moshi
 ) : BaseViewModel(moshi) {
 
@@ -33,5 +35,7 @@ class DeepLinkViewModel @Inject constructor(
             )
         }
 
-
+    fun clearLastNotificationChallenge() {
+        notificationCacheRepository.clearLastNotificationChallenge()
+    }
 }


### PR DESCRIPTION
There was a flow where we were not clearing the temporarily saved notification challenge, so it was possible for it to trigger for logging in a second time.