### PR TITLE
TIQR-476: Confirmation removal dialog, remove external accounts, personal info screen improvements

### DIFF
--- a/app/src/main/kotlin/nl/eduid/di/api/EduIdApi.kt
+++ b/app/src/main/kotlin/nl/eduid/di/api/EduIdApi.kt
@@ -9,6 +9,7 @@ import nl.eduid.di.model.EnrollResponse
 import nl.eduid.di.model.IdpScoping
 import nl.eduid.di.model.InstitutionNameResponse
 import nl.eduid.di.model.LinkedAccount
+import nl.eduid.di.model.LinkedAccountUpdateRequest
 import nl.eduid.di.model.RequestEduIdAccount
 import nl.eduid.di.model.RequestPhoneCode
 import nl.eduid.di.model.SelfAssertedName
@@ -89,7 +90,7 @@ interface EduIdApi {
 
     @PUT("/mobile/api/sp/institution")
     suspend fun removeConnection(
-        @Body account: LinkedAccount,
+        @Body updateRequest: LinkedAccountUpdateRequest,
     ): Response<UserDetails>
 
     @PUT("/mobile/api/sp/service")

--- a/app/src/main/kotlin/nl/eduid/di/model/EduIdModels.kt
+++ b/app/src/main/kotlin/nl/eduid/di/model/EduIdModels.kt
@@ -106,8 +106,18 @@ data class LinkedAccount(
 
 @Parcelize
 @JsonClass(generateAdapter = true)
+data class LinkedAccountUpdateRequest(
+    val eduPersonPrincipalName: String?,
+    val subjectId: String?,
+    val external: Boolean,
+    val idpScoping: String?
+) : Parcelable
+
+@Parcelize
+@JsonClass(generateAdapter = true)
 data class ExternalLinkedAccount(
     val idpScoping: String?,
+    val subjectId: String?,
     val issuer: ExternalLinkedAccountIssuer?,
     val subjectIssuer: String?,
     val firstName: String?,
@@ -125,7 +135,7 @@ data class ExternalLinkedAccount(
 data class ExternalLinkedAccountIssuer(
     val id: String,
     val name: String
-): Parcelable
+) : Parcelable
 
 @Parcelize
 @JsonClass(generateAdapter = true)
@@ -246,4 +256,4 @@ data class VerifyIssuer(
     val id: String?,
     val name: String?,
     val logo: String?
-): Parcelable
+) : Parcelable

--- a/app/src/main/kotlin/nl/eduid/di/model/ModelToState.kt
+++ b/app/src/main/kotlin/nl/eduid/di/model/ModelToState.kt
@@ -18,7 +18,7 @@ fun LinkedAccount.mapToInstitutionAccount(): PersonalInfo.InstitutionAccount? =
             affiliation
         }
         PersonalInfo.InstitutionAccount(
-            id = this.institutionIdentifier,
+            subjectId = this.subjectId ?: this.institutionIdentifier,
             role = role,
             roleProvider = this.schacHomeOrganization,
             institution = this.schacHomeOrganization,
@@ -32,7 +32,7 @@ fun LinkedAccount.mapToInstitutionAccount(): PersonalInfo.InstitutionAccount? =
 
 fun ExternalLinkedAccount.mapToInstitutionAccount(): PersonalInfo.InstitutionAccount? =
     PersonalInfo.InstitutionAccount(
-        id = this.idpScoping ?: "",
+        subjectId = this.subjectId ?: "",
         role = null,
         roleProvider = null,
         institution = this.issuer?.name ?: this.idpScoping ?: "",

--- a/app/src/main/kotlin/nl/eduid/screens/accountlinked/AccountLinkedScreen.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/accountlinked/AccountLinkedScreen.kt
@@ -190,10 +190,10 @@ private fun AccountLinkedContent(
     }
     personalInfo.linkedInternalAccounts.forEach { account ->
         ConnectionCardOld(
-            title = account.role ?: account.id,
+            title = account.role ?: account.subjectId,
             subtitle = stringResource(R.string.Profile_InstitutionAt_COPY, account.roleProvider ?: account.institution),
             institutionInfo = account,
-            onRemoveConnection = { removeConnection(account.id) },
+            onRemoveConnection = { removeConnection(account.subjectId) },
         )
     }
     PrimaryButton(

--- a/app/src/main/kotlin/nl/eduid/screens/homepage/HomePageNoAccount.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/homepage/HomePageNoAccount.kt
@@ -134,6 +134,7 @@ fun HomePageNoAccountContent(
                             waitingForVmEvent = false
                             viewModel.clearPreEnrollCheck()
                         },
+                        isDestroyAction = true,
                         onConfirm = {
                             //Continue to wait for the the VM event
                             //sent when the request for the deactivation code was requested successfully.

--- a/app/src/main/kotlin/nl/eduid/screens/homepage/HomePageWithAccountContent.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/homepage/HomePageWithAccountContent.kt
@@ -133,6 +133,7 @@ fun HomePageWithAccountContent(
                 dismissButtonLabel = stringResource(R.string.Button_Cancel_COPY),
                 confirmButtonLabel = stringResource(R.string.PinAndBioMetrics_SignIn_COPY),
                 onDismiss = viewModel::clearPromptForAuthTrigger,
+                isDestroyAction = false,
                 onConfirm = {
                     viewModel.clearPromptForAuthTrigger()
                     launchOAuth()

--- a/app/src/main/kotlin/nl/eduid/screens/personalinfo/PersonalInfoData.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/personalinfo/PersonalInfoData.kt
@@ -21,7 +21,7 @@ data class PersonalInfo(
     val isVerified = linkedInternalAccounts.isNotEmpty() || linkedExternalAccounts.isNotEmpty()
 
     data class InstitutionAccount(
-        val id: String,
+        val subjectId: String,
         val role: String?,
         val roleProvider: String?,
         val institution: String,
@@ -62,7 +62,7 @@ data class PersonalInfo(
 
         fun generateInstitutionAccountList() = listOf(
             InstitutionAccount(
-                id = "1",
+                subjectId = "1",
                 role = "Librarian",
                 roleProvider = "Library",
                 institution = "Unseen University",

--- a/app/src/main/kotlin/nl/eduid/screens/personalinfo/PersonalInfoRepository.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/personalinfo/PersonalInfoRepository.kt
@@ -17,6 +17,7 @@ import nl.eduid.di.model.EmailChangeRequest
 import nl.eduid.di.model.EnrollResponse
 import nl.eduid.di.model.IdpScoping
 import nl.eduid.di.model.LinkedAccount
+import nl.eduid.di.model.LinkedAccountUpdateRequest
 import nl.eduid.di.model.RequestPhoneCode
 import nl.eduid.di.model.SelfAssertedName
 import nl.eduid.di.model.Token
@@ -38,8 +39,8 @@ class PersonalInfoRepository(
         return processResponse(response = response)
     }
 
-    suspend fun removeConnectionResult(linkedAccount: LinkedAccount): Result<UserDetails> {
-        val response = eduIdApi.removeConnection(linkedAccount)
+    suspend fun removeConnectionResult(updateRequest: LinkedAccountUpdateRequest): Result<UserDetails> {
+        val response = eduIdApi.removeConnection(updateRequest)
         return processResponse(response = response)
     }
 

--- a/app/src/main/kotlin/nl/eduid/screens/personalinfo/PersonalInfoScreen.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/personalinfo/PersonalInfoScreen.kt
@@ -315,7 +315,7 @@ private fun ColumnScope.Organisations(
     )
     institutionAccounts.forEach { account ->
         ConnectionCard(
-            title = account.role ?: account.id,
+            title = account.role ?: account.subjectId,
             confirmedByInstitution = account,
             openVerifiedInformation = openVerifiedInformation
         )
@@ -351,13 +351,13 @@ private fun ColumnScope.NotVerifiedIdentity(
             text = stringResource(R.string.Profile_YourIdentity_COPY),
         )
         Text(
-            style = MaterialTheme.typography.bodyLarge,
+            style = MaterialTheme.typography.bodyLarge.copy(fontSize = 12.sp),
             text = stringResource(R.string.Profile_NotVerified_COPY),
             modifier = Modifier
                 .background(
                     MaterialTheme.colorScheme.tertiaryContainer, RoundedCornerShape(6.dp)
                 )
-                .padding(8.dp)
+                .padding(horizontal = 9.dp, vertical = 3.dp)
         )
     }
 

--- a/app/src/main/kotlin/nl/eduid/screens/personalinfo/verified/VerifiedPersonalInfoScreen.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/personalinfo/verified/VerifiedPersonalInfoScreen.kt
@@ -57,7 +57,7 @@ fun VerifiedPersonalInfoRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val errorData by viewModel.errorData.collectAsStateWithLifecycle()
     var waitingForVmEvent by rememberSaveable { mutableStateOf(false) }
-    var showConfirmRemovalDialogForSubjectId by rememberSaveable { mutableStateOf(null as String?) }
+    var showConfirmRemovalDialogForSubjectId by rememberSaveable { mutableStateOf<String?>(null) }
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     val onBack = remember(viewModel) { { goBack() } }
     errorData?.let {
@@ -100,9 +100,11 @@ fun VerifiedPersonalInfoRoute(
             },
             isDestroyAction = true,
             onConfirm = {
-                viewModel.removeConnection(showConfirmRemovalDialogForSubjectId!!)
-                showConfirmRemovalDialogForSubjectId = null
-                waitingForVmEvent = true
+                showConfirmRemovalDialogForSubjectId?.let { subjectId ->
+                    viewModel.removeConnection(subjectId)
+                    showConfirmRemovalDialogForSubjectId = null
+                    waitingForVmEvent = true
+                }
             }
         )
     }

--- a/app/src/main/kotlin/nl/eduid/screens/personalinfo/verified/VerifiedPersonalInfoViewModel.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/personalinfo/verified/VerifiedPersonalInfoViewModel.kt
@@ -72,10 +72,10 @@ class VerifiedPersonalInfoViewModel @Inject constructor(
 
     fun clearErrorData() = _errorData.update { null }
 
-    fun removeConnection(institutionId: String) {
+    fun removeConnection(subjectId: String) {
         viewModelScope.launch {
             _isProcessing.update { true }
-            assistant.removeConnection(institutionId)
+            assistant.removeConnection(subjectId)
             _isProcessing.update { false }
         }
     }

--- a/app/src/main/kotlin/nl/eduid/screens/scan/ScanScreen.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/scan/ScanScreen.kt
@@ -158,6 +158,7 @@ private fun ScanContent(
                 dismissButtonLabel = stringResource(R.string.Button_Cancel_COPY),
                 onDismiss = dismissErrorDialog,
                 confirmButtonLabel = stringResource(R.string.Button_Retry_COPY),
+                isDestroyAction = false,
                 onConfirm = retryErrorDialog
             )
         }

--- a/app/src/main/kotlin/nl/eduid/ui/AlertDialog.kt
+++ b/app/src/main/kotlin/nl/eduid/ui/AlertDialog.kt
@@ -1,5 +1,8 @@
 package nl.eduid.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -7,12 +10,17 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.window.DialogProperties
 import nl.eduid.R
 import nl.eduid.ui.theme.ColorAlertRed
+import nl.eduid.ui.theme.ColorMain_Green_400
 import nl.eduid.ui.theme.ColorScale_Gray_500
+import nl.eduid.ui.theme.ColorScale_Gray_Black
 import nl.eduid.ui.theme.EduidAppAndroidTheme
 
 @Composable
@@ -53,49 +61,57 @@ fun AlertDialogWithTwoButton(
     explanation: String,
     dismissButtonLabel: String,
     confirmButtonLabel: String,
+    isDestroyAction: Boolean,
     onDismiss: () -> Unit = {},
     onConfirm: () -> Unit = {},
 ) {
     val openDialog = remember { mutableStateOf(true) }
 
     if (openDialog.value) {
-        AlertDialog(onDismissRequest = {
-            // Dismiss the dialog when the user clicks outside the dialog or on the back
-            // button. If you want to disable that functionality, simply use an empty
-            // onDismissRequest.
-            openDialog.value = false
-            onDismiss()
-        }, title = {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleLarge,
-            )
-        }, text = {
-            Text(
-                text = explanation,
-                style = MaterialTheme.typography.bodyLarge,
-            )
-        }, confirmButton = {
-            TextButton(onClick = {
-                openDialog.value = false
-                onConfirm()
-            }) {
-                Text(
-                    text = confirmButtonLabel,
-                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
-                )
-            }
-        }, dismissButton = {
-            TextButton(onClick = {
+        Box( // Box for scrim
+            modifier = Modifier
+                .background(Color.Black.copy(alpha = 0.2f))
+                .fillMaxSize()
+        ) {
+            AlertDialog(onDismissRequest = {
+                // Dismiss the dialog when the user clicks outside the dialog or on the back
+                // button. If you want to disable that functionality, simply use an empty
+                // onDismissRequest.
                 openDialog.value = false
                 onDismiss()
-            }) {
+            }, title = {
                 Text(
-                    text = dismissButtonLabel,
-                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                    text = title,
+                    style = MaterialTheme.typography.titleLarge,
                 )
-            }
-        })
+            }, text = {
+                Text(
+                    text = explanation,
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }, confirmButton = {
+                PrimaryButton(
+                    onClick = {
+                        openDialog.value = false
+                        onConfirm()
+                    },
+                    text = confirmButtonLabel,
+                    buttonBackgroundColor = if (isDestroyAction) ColorAlertRed else ColorMain_Green_400
+                )
+            }, dismissButton = {
+                SecondaryButton(
+                    onClick = {
+                        openDialog.value = false
+                        onDismiss()
+                    },
+                    text = dismissButtonLabel,
+                )
+            },
+                containerColor = Color.White,
+                titleContentColor = ColorScale_Gray_Black,
+                textContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/nl/eduid/ui/ConnectionCard.kt
+++ b/app/src/main/kotlin/nl/eduid/ui/ConnectionCard.kt
@@ -264,7 +264,7 @@ private fun InstitutionInfoBlock(
     )
     Button(
         shape = RoundedCornerShape(CornerSize(6.dp)),
-        onClick = { onDeleteButtonClicked(institutionInfo.id) },
+        onClick = { onDeleteButtonClicked(institutionInfo.subjectId) },
         border = BorderStroke(1.dp, Color.Red),
         colors = ButtonDefaults.outlinedButtonColors(contentColor = ColorAlertRed),
         modifier = Modifier

--- a/app/src/main/kotlin/nl/eduid/ui/InfoField.kt
+++ b/app/src/main/kotlin/nl/eduid/ui/InfoField.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -295,14 +296,25 @@ fun ExpandableVerifiedInfoField(
     } else {
         MaterialTheme.colorScheme.surface
     }
-    ListItem(colors = ListItemDefaults.colors(
+    var listModifier: Modifier = Modifier
+    if (!isExpanded) {
+        listModifier = listModifier.height(72.dp)
+    }
+    ListItem(
+        colors = ListItemDefaults.colors(
         containerColor = containerColor,
         trailingIconColor = MaterialTheme.colorScheme.onSurface
     ),
         leadingContent = {
-            Image(
-                painter = painterResource(id = R.drawable.shield_tick_blue), contentDescription = ""
-            )
+            Column(
+                modifier = Modifier.height(56.dp),
+                verticalArrangement = Arrangement.Center
+            ) {
+
+                Image(
+                    painter = painterResource(id = R.drawable.shield_tick_blue), contentDescription = ""
+                )
+            }
         },
         headlineContent = {
             Text(
@@ -357,19 +369,24 @@ fun ExpandableVerifiedInfoField(
             }
         },
         trailingContent = {
-            if (isExpanded) {
-                Icon(
-                    imageVector = Icons.Outlined.KeyboardArrowUp,
-                    contentDescription = "",
-                )
-            } else {
-                Icon(
-                    imageVector = Icons.Outlined.KeyboardArrowDown,
-                    contentDescription = "",
-                )
+            Column(
+                modifier = Modifier.height(56.dp),
+                verticalArrangement = Arrangement.Center
+            ) {
+                if (isExpanded) {
+                    Icon(
+                        imageVector = Icons.Outlined.KeyboardArrowUp,
+                        contentDescription = "",
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Outlined.KeyboardArrowDown,
+                        contentDescription = "",
+                    )
+                }
             }
         },
-        modifier = modifier
+        modifier = listModifier
             .border(
                 color = MaterialTheme.colorScheme.onSurface,
                 shape = RoundedCornerShape(6.dp),


### PR DESCRIPTION
- Adds a confirmation dialog before trying to remove an account link
- Minor UI fixes on the personal info screen (jumping icons in the expandable control, incorrect font sizes)
- Aligned the dialog to match design: button color is red if the action is a destroy one, fixed colors and added scrim
- External accounts can now be removed as well