### PR TITLE
TIQR-502: Fix crash an aborting the account linking flow

### DIFF
--- a/app/src/main/kotlin/nl/eduid/graphs/MainGraph.kt
+++ b/app/src/main/kotlin/nl/eduid/graphs/MainGraph.kt
@@ -312,7 +312,6 @@ fun MainGraph(
     composable(Graph.FIRST_TIME_DIALOG) { entry ->
         val viewModel = hiltViewModel<LinkAccountViewModel>(entry)
         FirstTimeDialogRoute(viewModel = viewModel,
-            goToAccountLinked = { navController.goToWithPopCurrent(AccountLinked.routeWithRegistrationFlowParam(true)) },
             skipThis = {
                 navController.navigate(Graph.HOME_PAGE) {
                     //Clear existing home page that has no account

--- a/app/src/main/kotlin/nl/eduid/screens/firsttimedialog/FirstTimeDialogScreen.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/firsttimedialog/FirstTimeDialogScreen.kt
@@ -50,12 +50,14 @@ import nl.eduid.ui.theme.AlertWarningBackground
 import nl.eduid.ui.theme.EduidAppAndroidTheme
 
 @Composable
-fun FirstTimeDialogRoute(viewModel: LinkAccountViewModel, goToAccountLinked: () -> Unit, skipThis: () -> Unit) {
+fun FirstTimeDialogRoute(viewModel: LinkAccountViewModel, skipThis: () -> Unit) {
     var isGettingLinkUrl by rememberSaveable { mutableStateOf(false) }
     var isLinkingStarted by rememberSaveable { mutableStateOf(false) }
     val launcher = rememberLauncherForActivityResult(contract = LinkAccountContract(), onResult = { _ ->
         if (isLinkingStarted) {
-            goToAccountLinked()
+            // This part is called when the user came back to the app without linking anything
+            // (otherwise we would go via a deeplink to the success / error screen).
+            // In this case we do nothing. The user can choose to link again, or just press on the skip button.
             isLinkingStarted = false
         }
     })


### PR DESCRIPTION
When the user aborted the account linking flow (came back to the app without finishing the process), the app would try to navigate to a non-existent page.
Instead, we stay on the page, so the user can either skip the linking or try to do it again.