### PR TITLE
TIQR-503: Add clearer error message, whitelist Huawei Browser

### DIFF
--- a/app/src/main/kotlin/nl/eduid/di/assist/AuthenticationAssistant.kt
+++ b/app/src/main/kotlin/nl/eduid/di/assist/AuthenticationAssistant.kt
@@ -2,8 +2,19 @@ package nl.eduid.di.assist
 
 import android.content.Context
 import android.net.Uri
-import net.openid.appauth.*
+import net.openid.appauth.AppAuthConfiguration
+import net.openid.appauth.AuthState
+import net.openid.appauth.AuthorizationException
+import net.openid.appauth.AuthorizationResponse
+import net.openid.appauth.AuthorizationService
+import net.openid.appauth.AuthorizationServiceConfiguration
+import net.openid.appauth.ClientAuthentication
+import net.openid.appauth.RegistrationRequest
+import net.openid.appauth.RegistrationResponse
+import net.openid.appauth.TokenResponse
 import net.openid.appauth.browser.BrowserAllowList
+import net.openid.appauth.browser.Browsers
+import net.openid.appauth.browser.VersionRange
 import net.openid.appauth.browser.VersionedBrowserMatcher
 import net.openid.appauth.connectivity.DefaultConnectionBuilder
 import nl.eduid.screens.oauth.Configuration
@@ -118,7 +129,14 @@ class AuthenticationAssistant {
                 BrowserAllowList(
                     VersionedBrowserMatcher.CHROME_BROWSER,
                     VersionedBrowserMatcher.FIREFOX_BROWSER,
-                    VersionedBrowserMatcher.SAMSUNG_BROWSER
+                    VersionedBrowserMatcher.SAMSUNG_BROWSER,
+                    // Huawei phones usually don't have Chrome but have their own browser instead, so we need to whitelist that as well:
+                    VersionedBrowserMatcher(
+                        "com.huawei.browser",
+                        "OOzdSEud0D3ocrJZnneyTsxFgkMlYaQEp4A6gX-j4DBVe7Lecf_KLydHcjA6Q0apfZUcFGIK1UqAwcl8cd6I8w==",
+                        false,
+                        VersionRange.ANY_VERSION
+                    )
                 )
             )
             builder.setConnectionBuilder(DefaultConnectionBuilder.INSTANCE)

--- a/app/src/main/kotlin/nl/eduid/screens/oauth/OAuthViewModel.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/oauth/OAuthViewModel.kt
@@ -1,5 +1,6 @@
 package nl.eduid.screens.oauth
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.res.Resources
@@ -69,10 +70,17 @@ class OAuthViewModel @Inject constructor(
             uiState = UiState(OAuthStep.Initialized(authorizationIntent))
         } catch (e: Exception) {
             val argument = e.message ?: e.localizedMessage
+            val messageId = if (e is ActivityNotFoundException) {
+                R.string.AppData_InitializationError_NoSupportedBrowserFound_COPY
+            } else if (argument == null) {
+                R.string.AppData_InitializationError_Generic_COPY
+            } else {
+                R.string.AppData_InitializationError_WithException_COPY
+            }
             uiState = UiState(
                 OAuthStep.Error, ErrorData(
                     titleId = R.string.Generic_RequestError_Title_COPY,
-                    messageId = if (argument == null) R.string.AppData_InitializationError_Generic_COPY else R.string.AppData_InitializationError_WithException_COPY,
+                    messageId = messageId,
                     messageArg = argument
                 )
             )

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -838,5 +838,6 @@
   <string name="Profile_You_COPY">"Zelf"</string>
   <string name="ManageAccount_CreatedAt_COPY">"EEEE, dd MMMM yyyy 'om' HH:MM"</string>
   <string name="AppData_InitializationError_Generic_COPY">"AppData kan niet worden geïnitialiseerd. Probeer het opnieuw."</string>
+  <string name="AppData_InitializationError_NoSupportedBrowserFound_COPY">"AppData kan niet worden geïnitialiseerd. Geen ondersteunde browser gevonden."</string>
   <string name="AppData_InitializationError_WithException_COPY">"AppData kan niet worden geïnitialiseerd. Reden: %1$s"</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -838,5 +838,6 @@
   <string name="Profile_You_COPY">"you"</string>
   <string name="ManageAccount_CreatedAt_COPY">"EEEE, dd MMMM yyyy 'at' HH:MM"</string>
   <string name="AppData_InitializationError_Generic_COPY">"Failed to initialize AppData. Please retry."</string>
+  <string name="AppData_InitializationError_NoSupportedBrowserFound_COPY">"Failed to initialize AppData. No supported browser found."</string>
   <string name="AppData_InitializationError_WithException_COPY">"Failed to initialize AppData. Reason: %1$s"</string>
 </resources>

--- a/localizations.yaml
+++ b/localizations.yaml
@@ -66,6 +66,10 @@ ANDROID:
         COPY:
           en: Failed to initialize AppData. Please retry.
           nl: AppData kan niet worden geïnitialiseerd. Probeer het opnieuw.
+      NoSupportedBrowserFound:
+        COPY:
+          en: "Failed to initialize AppData. No supported browser found."
+          nl: "AppData kan niet worden geïnitialiseerd. Geen ondersteunde browser gevonden."
       WithException:
         COPY:
           en: "Failed to initialize AppData. Reason: %1{{s}}"


### PR DESCRIPTION
There were some cases on devices without Google software (GrapheneOS, Huawei) that the AppData initailization failed because no supported browser could be found.
I have cleared up the error message, and also whitelisted the Huawei Browser:
![Screenshot_1738140691](https://github.com/user-attachments/assets/2cfd4c2a-118f-419f-b0bc-6dfdebec2df1)
