### PR TITLE
TIQR-527: Fix strings, add support for verify-already-used endpoint

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -287,21 +287,42 @@
 
                 <data
                     android:host="*.eduid.nl"
-                    android:scheme="https"
                     android:path="/client/mobile/external-account-linked"
+                    android:scheme="https"
                     tools:ignore="IntentFilterUniqueDataAttributes" />
                 <data
-                    android:scheme="eduid"
                     android:host="*"
                     android:path="/client/mobile/external-account-linked"
+                    android:scheme="eduid"
                     tools:ignore="IntentFilterUniqueDataAttributes" />
+            </intent-filter>
+
+            <!-- Subject already linked -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="*.eduid.nl"
+                    android:pathPrefix="/client/mobile/verify-already-used"
+                    android:scheme="https"
+                    tools:ignore="IntentFilterUniqueDataAttributes" />
+
+                <data
+                    android:host="*"
+                    android:path="/client/mobile/verify-already-used"
+                    android:scheme="eduid"
+                    tools:ignore="IntentFilterUniqueDataAttributes" />
+
             </intent-filter>
         </activity>
 
         <activity
             android:name="net.openid.appauth.RedirectUriReceiverActivity"
-            tools:node="replace"
-            android:exported="true">
+            android:exported="true"
+            tools:node="replace">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 

--- a/app/src/main/kotlin/nl/eduid/graphs/MainGraph.kt
+++ b/app/src/main/kotlin/nl/eduid/graphs/MainGraph.kt
@@ -354,6 +354,12 @@ fun MainGraph(
                 uriPattern = AccountLinked.getUriPatternFailed(baseUrl)
             },
             navDeepLink {
+                uriPattern = AccountLinked.getUriPatternSubjectAlreadyLinked(baseUrl)
+            },
+            navDeepLink {
+                uriPattern = AccountLinked.getUriPatternSubjectAlreadyLinkedCustomScheme()
+            },
+            navDeepLink {
                 uriPattern = AccountLinked.getUriPatternExpired(baseUrl)
             },
         ),

--- a/app/src/main/kotlin/nl/eduid/graphs/Routes.kt
+++ b/app/src/main/kotlin/nl/eduid/graphs/Routes.kt
@@ -55,6 +55,8 @@ object AccountLinked {
     fun getUriPatternExternalLinkOKCustomScheme() = "eduid:///client/mobile/external-account-linked"
     fun getUriPatternFailed(baseUrl: String) = "$baseUrl/client/mobile/eppn-already-linked"
     fun getUriPatternExpired(baseUrl: String) = "$baseUrl/client/mobile/expired"
+    fun getUriPatternSubjectAlreadyLinked(baseUrl: String) = "$baseUrl/client/mobile/verify-already-used"
+    fun getUriPatternSubjectAlreadyLinkedCustomScheme() = "eduid:///client/mobile/verify-already-used"
 
     const val isRegistrationFlowArg = "is_registration_flow"
 

--- a/app/src/main/kotlin/nl/eduid/screens/accountlinked/AccountLinkedScreen.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/accountlinked/AccountLinkedScreen.kt
@@ -73,10 +73,19 @@ fun AccountLinkedScreen(
     ) {
 
         when (result) {
-            is ResultAccountLinked.FailedAlreadyLinkedResult -> AccountFailedLinkContent(
+            is ResultAccountLinked.FailedInstitutionAlreadyLinkedResult -> AccountFailedLinkContent(
                 explanation = stringResource(
-                    R.string.NameUpdated_Title_FailReason_AlreadyLinked_COPY, result.withEmail
+                    R.string.EppnAlreadyLinked_Info_COPY, result.withEmail
                 ), continueToHome = continueToHome
+            )
+
+            is ResultAccountLinked.FailedExternalAccountAlreadyLinkedResult -> AccountFailedLinkContent(
+                overrideTitle = stringResource(R.string.EppnAlreadyLinked_Title_VerificationFailed_COPY),
+                explanation = if (result.withEmail == null) {
+                    stringResource(R.string.EppnAlreadyLinked_InfoExternalAccountWithoutEmail_COPY)
+                } else {
+                    stringResource(R.string.EppnAlreadyLinked_InfoExternalAccountWithEmail_COPY, result.withEmail)
+                }, continueToHome = continueToHome
             )
 
             ResultAccountLinked.FailedExpired -> AccountFailedLinkContent(
@@ -113,6 +122,7 @@ fun AccountLinkedScreen(
 @Composable
 private fun AccountFailedLinkContent(
     explanation: String,
+    overrideTitle: String? = null,
     continueToHome: () -> Unit = {},
 ) = Column(
     modifier = Modifier
@@ -126,19 +136,31 @@ private fun AccountFailedLinkContent(
         modifier = Modifier.fillMaxSize()
     ) {
         Spacer(Modifier.height(36.dp))
-        Text(
-            style = MaterialTheme.typography.titleLarge.copy(
-                textAlign = TextAlign.Start, color = ColorMain_Green_400
-            ),
-            text = stringResource(R.string.NameUpdated_Title_YourSchool_COPY),
-            modifier = Modifier.fillMaxWidth()
-        )
-        Spacer(Modifier.height(12.dp))
-        Text(
-            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.SemiBold),
-            text = stringResource(R.string.NameUpdated_Title_ContactedError_COPY),
-            modifier = Modifier.fillMaxWidth()
-        )
+        if (overrideTitle != null) {
+            Text(
+                style = MaterialTheme.typography.titleLarge.copy(
+                    fontWeight = FontWeight.SemiBold,
+                    textAlign = TextAlign.Start,
+                    color = ColorMain_Green_400
+                ),
+                text = overrideTitle,
+                modifier = Modifier.fillMaxWidth()
+            )
+        } else {
+            Text(
+                style = MaterialTheme.typography.titleLarge.copy(
+                    textAlign = TextAlign.Start, color = ColorMain_Green_400
+                ),
+                text = stringResource(R.string.NameUpdated_Title_YourSchool_COPY),
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(Modifier.height(12.dp))
+            Text(
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.SemiBold),
+                text = stringResource(R.string.NameUpdated_Title_ContactedError_COPY),
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
         Spacer(Modifier.height(12.dp))
         Text(
             text = explanation,

--- a/app/src/main/kotlin/nl/eduid/screens/accountlinked/ResultAccountLinked.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/accountlinked/ResultAccountLinked.kt
@@ -4,14 +4,17 @@ import android.net.Uri
 
 sealed interface ResultAccountLinked {
     data class Success(val institutionId: String?) : ResultAccountLinked
-    data class FailedAlreadyLinkedResult(val withEmail: String) : ResultAccountLinked
+    data class FailedInstitutionAlreadyLinkedResult(val withEmail: String) : ResultAccountLinked
+    data class FailedExternalAccountAlreadyLinkedResult(val withEmail: String?) : ResultAccountLinked
     data object FailedExpired : ResultAccountLinked
 
     companion object {
         fun fromRedirectUrl(uri: Uri) = when {
             uri.path?.contains("expired", true) ?: false -> FailedExpired
             uri.path?.contains("already-linked")
-                ?: false -> FailedAlreadyLinkedResult(uri.getQueryParameter("email") ?: "")
+                ?: false -> FailedInstitutionAlreadyLinkedResult(uri.getQueryParameter("email") ?: "")
+            uri.path?.contains("verify-already-used")
+                ?: false -> FailedExternalAccountAlreadyLinkedResult(uri.getQueryParameter("email"))
             else -> {
                 val institutionId = uri.getQueryParameter("institution")
                 Success(institutionId)

--- a/app/src/main/kotlin/nl/eduid/screens/personalinfo/banners/ControlCodeBanner.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/personalinfo/banners/ControlCodeBanner.kt
@@ -58,7 +58,7 @@ fun ControlCodeBanner(
                     fontWeight = FontWeight.SemiBold,
                     color = MaterialTheme.colorScheme.onPrimaryContainer
                 ),
-                text = stringResource(R.string.Profile_VerifyWithControlCode_Title_COPY),
+                text = stringResource(R.string.ServiceDesk_ControlCode_Banner_COPY),
             )
         }
         Row {
@@ -74,7 +74,7 @@ fun ControlCodeBanner(
                     .sizeIn(minHeight = 40.dp),
             ) {
                 Text(
-                    text = stringResource(R.string.Profile_VerifyWithControlCode_Button_COPY),
+                    text = stringResource(R.string.ServiceDesk_ControlCode_ShowCode_COPY),
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.bodyLarge.copy(
                         fontWeight = FontWeight.SemiBold,

--- a/app/src/main/kotlin/nl/eduid/screens/verifyidentity/VerifyIdentityScreen.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/verifyidentity/VerifyIdentityScreen.kt
@@ -269,7 +269,7 @@ fun VerifyIdentityScreenContent(
             ) {
                 SecondaryButton(
                     modifier = Modifier.fillMaxWidth(),
-                    text = stringResource(R.string.VerifyIdentity_ICantUseTheseMethods_COPY),
+                    text = stringResource(R.string.ServiceDesk_ControlCode_CantUse_COPY),
                     onClick = goToFallbackMethodScreen
                 )
             }

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -111,8 +111,11 @@
   <string name="Profile_VerifyStudent_AddInstitutionConfirmation_COPY">"Als je doorgaat word je gevraagd in te loggen via de onderwijsinstelling die je wilt koppelen. Selecteer eerst de instelling die je wilt koppelen en log daarna in.&lt;br/&gt; &lt;br/&gt;Nadat je succesvol bent ingelogd kom je hier weer terug."</string>
   <string name="Profile_VerifyParty_AddInstitution_COPY">"Koppel instelling"</string>
   <string name="Profile_VerifyParty_AddInstitutionConfirmation_COPY">"Als je doorgaat word je gevraagd in te loggen via de onderwijsinstelling die je wilt koppelen. Selecteer eerst de instelling die je wilt koppelen en log daarna in.&lt;br/&gt; &lt;br/&gt;Nadat je succesvol bent ingelogd kom je hier weer terug."</string>
-  <string name="EppnAlreadyLinked_Title_COPY">"Koppeling niet gemaakt!"</string>
+  <string name="EppnAlreadyLinked_Title_AccountNotConnected_COPY">"Koppeling niet gemaakt!"</string>
+  <string name="EppnAlreadyLinked_Title_VerificationFailed_COPY">"Verificatie mislukt!"</string>
   <string name="EppnAlreadyLinked_Info_COPY">"Je eduID kon niet worden gekoppeld. Het account waarmee je zojuist bent ingelogd, is al aan een ander eduID gekoppeld: %1$s."</string>
+  <string name="EppnAlreadyLinked_InfoExternalAccountWithoutEmail_COPY">"Je eduID kon niet worden geverifïeerd. Het externe account waarmee je zojuist bent ingelogd, is al aan een ander eduID-account gekoppeld."</string>
+  <string name="EppnAlreadyLinked_InfoExternalAccountWithEmail_COPY">"Je eduID kon niet worden geverifïeerd. Het externe account waarmee je zojuist bent ingelogd, is al aan een ander eduID-account gekoppeld: %1$s"</string>
   <string name="EppnAlreadyLinked_RetryButton_COPY">"Opnieuw proberen"</string>
   <string name="Edit_Title_COPY">"Aanpassen profielgegevens"</string>
   <string name="Edit_Info_COPY">"Vul je volledige naam in."</string>
@@ -864,6 +867,7 @@
   <string name="ServiceDesk_ControlCode_Banner_COPY">"Bevestig je identiteit bij een eduID Service Desk. Dit doe je door je identiteitsbewijs en controlecode te laten zien."</string>
   <string name="ServiceDesk_ControlCode_ShowCode_COPY">"Toon code"</string>
   <string name="ServiceDesk_ControlCode_ValidityCode_COPY">"Je code is nog geldig voor &#37;1$s dagen."</string>
+  <string name="ServiceDesk_ControlCode_CantUse_COPY">"Ik kan geen van bovenstaande manieren gebruiken"</string>
   <string name="Button_OK_COPY">"OK"</string>
   <string name="Button_Cancel_COPY">"Annuleren"</string>
   <string name="Button_Retry_COPY">"Probeer opnieuw"</string>
@@ -879,4 +883,5 @@
   <string name="ManageAccount_CreatedAt_COPY">"EEEE, dd MMMM yyyy 'om' HH:MM"</string>
   <string name="AppData_InitializationError_Generic_COPY">"AppData kan niet worden geïnitialiseerd. Probeer het opnieuw."</string>
   <string name="AppData_InitializationError_WithException_COPY">"AppData kan niet worden geïnitialiseerd. Reden: %1$s"</string>
+  <string name="AppData_InitializationError_NoSupportedBrowserFound_COPY">"AppData kan niet worden geïnitialiseerd. Geen ondersteunde browser gevonden."</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,8 +111,11 @@
   <string name="Profile_VerifyStudent_AddInstitutionConfirmation_COPY">"When you proceed you will be asked to login at the institution you want to connect to your eduID. First, select which institution you want to connect; then, login at that institution.&lt;br/&gt;&lt;br/&gt;After a successful login you will come back here."</string>
   <string name="Profile_VerifyParty_AddInstitution_COPY">"Connect institution"</string>
   <string name="Profile_VerifyParty_AddInstitutionConfirmation_COPY">"When you proceed you will be asked to login at the institution you want to connect to your eduID. First, select which institution you want to connect; then, login at that institution.&lt;br/&gt;&lt;br/&gt;After a successful login you will come back here."</string>
-  <string name="EppnAlreadyLinked_Title_COPY">"Account not connected!"</string>
+  <string name="EppnAlreadyLinked_Title_AccountNotConnected_COPY">"Account not connected!"</string>
+  <string name="EppnAlreadyLinked_Title_VerificationFailed_COPY">"Verification failed!"</string>
   <string name="EppnAlreadyLinked_Info_COPY">"Your eduID could not be connected. The account with which you just logged in, is already connected to a different eduID: %1$s."</string>
+  <string name="EppnAlreadyLinked_InfoExternalAccountWithoutEmail_COPY">"Your eduID could not be verified. The external account with which you just logged in, is already linked to a different eduID account."</string>
+  <string name="EppnAlreadyLinked_InfoExternalAccountWithEmail_COPY">"Your eduID could not be verified. The external account with which you just logged in, is already linked to a different eduID account: %1$s"</string>
   <string name="EppnAlreadyLinked_RetryButton_COPY">"Retry"</string>
   <string name="Edit_Title_COPY">"Name"</string>
   <string name="Edit_Info_COPY">"Please provide your full name."</string>
@@ -708,7 +711,7 @@
   <string name="WelcomeToApp_ReturnBrowserText_COPY">"Continue in your browser to finish the connection of this app to your eduID"</string>
   <string name="CreateEduID_ErrorCreateFailed_Title_COPY">"Could not create your eduID account"</string>
   <string name="CreateEduID_ErrorCreateFailed_Message_COPY">"Something went wrong while creating your account. Please try again."</string>
-  <string name="CreateEduID_LandingPage_MainText_COPY">"Verifiy who you are in the field of education and research"</string>
+  <string name="CreateEduID_LandingPage_MainText_COPY">"Verify who you are in the field of education and research"</string>
   <string name="CreateEduID_LandingPage_SignInButton_COPY">"Log in"</string>
   <string name="CreateEduID_LandingPage_ScanQrButton_COPY">"Scan QR code"</string>
   <string name="CreateEduID_LandingPage_NoEduIdButton_COPY">"I don't have an eduID"</string>
@@ -864,6 +867,7 @@
   <string name="ServiceDesk_ControlCode_Banner_COPY">"Verify your identity at an eduID Service Desk by presenting your ID and verification code."</string>
   <string name="ServiceDesk_ControlCode_ShowCode_COPY">"Show code"</string>
   <string name="ServiceDesk_ControlCode_ValidityCode_COPY">"Your code is valid for &#37;1$s more days."</string>
+  <string name="ServiceDesk_ControlCode_CantUse_COPY">"I can't use any of the above methods"</string>
   <string name="Button_OK_COPY">"OK"</string>
   <string name="Button_Cancel_COPY">"Cancel"</string>
   <string name="Button_Retry_COPY">"Retry"</string>
@@ -879,4 +883,5 @@
   <string name="ManageAccount_CreatedAt_COPY">"EEEE, dd MMMM yyyy 'at' HH:MM"</string>
   <string name="AppData_InitializationError_Generic_COPY">"Failed to initialize AppData. Please retry."</string>
   <string name="AppData_InitializationError_WithException_COPY">"Failed to initialize AppData. Reason: %1$s"</string>
+  <string name="AppData_InitializationError_NoSupportedBrowserFound_COPY">"Failed to initialize AppData. No supported browser found."</string>
 </resources>

--- a/localizations.yaml
+++ b/localizations.yaml
@@ -72,6 +72,10 @@ ANDROID:
         COPY:
           en: "Failed to initialize AppData. Reason: %1{{s}}"
           nl: "AppData kan niet worden geïnitialiseerd. Reden: %1{{s}}"
+      NoSupportedBrowserFound:
+        COPY:
+          en: "Failed to initialize AppData. No supported browser found."
+          nl: "AppData kan niet worden geïnitialiseerd. Geen ondersteunde browser gevonden."
 SHARED:
   About:
     Info:
@@ -586,9 +590,14 @@ SHARED:
             succesvol bent ingelogd kom je hier weer terug.
   EppnAlreadyLinked:
     Title:
-      COPY:
-        en: Account not connected!
-        nl: Koppeling niet gemaakt!
+      AccountNotConnected:
+        COPY:
+          en: Account not connected!
+          nl: Koppeling niet gemaakt!
+      VerificationFailed:
+        COPY:
+          en: Verification failed!
+          nl: Verificatie mislukt!
     Info:
       COPY:
         en: >-
@@ -599,6 +608,22 @@ SHARED:
           Je eduID kon niet worden gekoppeld. Het account waarmee je
           zojuist bent ingelogd, is al aan een ander eduID gekoppeld:
           %1{{s}}.
+    InfoExternalAccountWithoutEmail:
+      COPY:
+        en: >-
+          Your eduID could not be verified.
+          The external account with which you just logged in, is already linked to a different eduID account.
+        nl: >-
+          Je eduID kon niet worden geverifïeerd.
+          Het externe account waarmee je zojuist bent ingelogd, is al aan een ander eduID-account gekoppeld.
+    InfoExternalAccountWithEmail:
+      COPY:
+        en: >-
+          Your eduID could not be verified.
+          The external account with which you just logged in, is already linked to a different eduID account: %1{{s}}
+        nl: >-
+          Je eduID kon niet worden geverifïeerd.
+          Het externe account waarmee je zojuist bent ingelogd, is al aan een ander eduID-account gekoppeld: %1{{s}}
     RetryButton:
       COPY:
         en: Retry
@@ -3467,7 +3492,7 @@ SHARED:
     LandingPage:
       MainText:
         COPY:
-          en: Verifiy who you are in the field of education and research
+          en: Verify who you are in the field of education and research
           nl: Bewijs wie je bent in het veld van onderwijs en onderzoek
       SignInButton:
         COPY:
@@ -4154,3 +4179,7 @@ SHARED:
         COPY:
           en: "Your code is valid for %1$s more days."
           nl: "Je code is nog geldig voor %1$s dagen."
+      CantUse:
+        COPY:
+          en: "I can't use any of the above methods"
+          nl: "Ik kan geen van bovenstaande manieren gebruiken"


### PR DESCRIPTION
- Readded the missing strings, fixed a typo
- Added support for the `verify-already-used` path, with matching error messages