### PR TITLE
TIQR-549: Use keyboard for phone number

### DIFF
--- a/app/src/main/kotlin/nl/eduid/screens/recovery/requestsms/PhoneRequestCodeScreen.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/recovery/requestsms/PhoneRequestCodeScreen.kt
@@ -161,7 +161,8 @@ private fun PhoneRequestCodeContent(
             colors = outlinedTextColors(),
             value = uiState.input,
             keyboardOptions = KeyboardOptions(
-                imeAction = ImeAction.Done, keyboardType = KeyboardType.Number
+                imeAction = ImeAction.Done,
+                keyboardType = KeyboardType.Phone,
             ),
             keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
             onValueChange = onValueChange,


### PR DESCRIPTION
Changes the keyboard type to phone number, which will show the + sign as well to support international phone numbers (or you could use the `00` prefix instead)