### PR TITLE
TIQR-578: Fix linked account not being removed

### DIFF
--- a/app/src/main/kotlin/nl/eduid/di/assist/DataAssistant.kt
+++ b/app/src/main/kotlin/nl/eduid/di/assist/DataAssistant.kt
@@ -119,7 +119,7 @@ constructor(
     suspend fun removeConnection(subjectId: String) = withContext(dispatcher) {
         val currentDetails = currentCachedSettings() ?: fetchDetails()
         val linkedAccount =
-            currentDetails?.linkedAccounts?.firstOrNull { it.subjectId == subjectId }
+            currentDetails?.linkedAccounts?.firstOrNull { it.subjectId == subjectId || it.institutionIdentifier == subjectId }
         linkedAccount?.let {
             val updateRequest = LinkedAccountUpdateRequest(
                 eduPersonPrincipalName = it.eduPersonPrincipalName,


### PR DESCRIPTION
Linked accounts do not have a subjectID but are using institutionIdentifier instead.