### PR TITLE
a11y: mark DataAndActivityScreen explainer icon as decorative

### DIFF
--- a/app/src/main/kotlin/nl/eduid/screens/dataactivity/DataAndActivityScreen.kt
+++ b/app/src/main/kotlin/nl/eduid/screens/dataactivity/DataAndActivityScreen.kt
@@ -114,7 +114,7 @@ fun DataAndActivityScreenContent(
     Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
         Icon(
             painter = painterResource(id = R.drawable.ic_key_data_activity_access),
-            contentDescription = "",
+            contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurface,
         )
         Text(


### PR DESCRIPTION
Closes #263.

The `Icon` at `DataAndActivityScreen.kt:117` had `contentDescription = \"\"` next to a `Text` that already explains what the icon means (`DataActivity_ExplainIcon_COPY` = \"This icon indicates the service has access to your info.\"). An empty content description is announced by TalkBack as a generic \"image\", which is the exact \"missing text alternative\" failure the issue calls out.

## Fix

Set `contentDescription = null` to mark the icon as **decorative**. TalkBack will skip the icon and read only the adjacent explanatory `Text`, avoiding duplicate announcements while still conveying the meaning to screen reader users.

This matches the pattern already used throughout the codebase for decorative icons paired with visible labels — e.g. `LoginInfoCard`, `ConnectionCard`, `SvgImage`, `VerifyIdentityScreen`.

## Trade-off vs. adding alt text

The issue suggests adding alt text like \"has access to your information\". Using that as `contentDescription` on the icon would cause TalkBack to read the message twice (once for the icon, once for the adjacent `Text`). `null` gives a cleaner screen reader experience here because the visible text is already the alt text — happy to switch to an explicit description (adding a new string to `localizations.yaml`) if you'd prefer that approach.